### PR TITLE
Fix support check when determining cache type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # fast-copy CHANGELOG
 
+## 1.1.1
+
+* Fix cache using `WeakSet` when there was support for `WeakMap`s instead of `WeakSet`s (in case one was polyfilled but not the other)
+
 ## 1.1.0
 
 * Add TypeScript and FlowType bindings

--- a/DEV_ONLY/App.js
+++ b/DEV_ONLY/App.js
@@ -13,6 +13,9 @@ function Foo(value) {
 }
 
 const object = {
+  arguments: (function() {
+    return arguments;
+  }('foo', 'bar', 'baz')),
   array: ['foo', {bar: 'baz'}],
   arrayBuffer: new ArrayBuffer(8),
   boolean: true,

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ const propertyIsEnumerable = Object.prototype.propertyIsEnumerable;
  * @returns {Object|Weakset} the new cache object
  */
 export const getNewCache = () =>
-  HAS_WEAKMAP_SUPPORT
+  HAS_WEAKSET_SUPPORT
     ? new WeakSet()
     : Object.create({
       _values: [],

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,9 @@ const SIMPLE_TYPES = {
 };
 
 const COMPLEX_TYPES = {
+  arguments: (function() {
+    return arguments;
+  }('foo', 'bar', 'baz')),
   array: ['foo', {bar: 'baz'}],
   arrayBuffer: new ArrayBuffer(8),
   buffer: new Buffer('this is a test buffer'),
@@ -111,12 +114,16 @@ test.serial('if copy will copy the simple types directly', (t) => {
 test.serial('if copy will copy the complex types deeply', (t) => {
   const result = copy(COMPLEX_TYPES);
 
-  t.not(result, COMPLEX_TYPES);
-  t.deepEqual(result, COMPLEX_TYPES);
+  const {arguments: originalArgs, ...complexTypes} = COMPLEX_TYPES;
+  const {arguments: newArgs, ...equivalentComplexTypes} = result;
 
-  Object.keys(COMPLEX_TYPES).forEach((key) => {
-    t.not(result[key], COMPLEX_TYPES[key]);
-    t.deepEqual(result[key], COMPLEX_TYPES[key], key);
+  t.not(equivalentComplexTypes, complexTypes);
+  t.deepEqual(equivalentComplexTypes, complexTypes);
+  t.deepEqual(newArgs, {...originalArgs});
+
+  Object.keys(complexTypes).forEach((key) => {
+    t.not(equivalentComplexTypes[key], complexTypes[key]);
+    t.deepEqual(equivalentComplexTypes[key], complexTypes[key], key);
   });
 });
 
@@ -150,7 +157,7 @@ test.serial('if copy will handle when buffers are not supported', (t) => {
   constants.HAS_BUFFER_SUPPORT = false;
 
   const cleanComplexTypes = Object.keys(COMPLEX_TYPES).reduce((types, key) => {
-    if (key !== 'buffer') {
+    if (key !== 'buffer' && key !== 'arguments') {
       types[key] = COMPLEX_TYPES[key];
     }
 
@@ -175,6 +182,7 @@ test.serial('if copy will handle when arrayBuffers are not supported', (t) => {
   const cleanComplexTypes = Object.keys(COMPLEX_TYPES).reduce((types, key) => {
     if (
       !~[
+        'arguments',
         'arrayBuffer',
         'dataView',
         'float32Array',

--- a/test/utils.js
+++ b/test/utils.js
@@ -13,9 +13,9 @@ test.serial('if getNewCache will return a new WeakSet when support is present', 
 });
 
 test.serial('if getNewCache will return a new WeakSet-like object when support is not present', (t) => {
-  const support = constants.HAS_WEAKMAP_SUPPORT;
+  const support = constants.HAS_WEAKSET_SUPPORT;
 
-  constants.HAS_WEAKMAP_SUPPORT = false;
+  constants.HAS_WEAKSET_SUPPORT = false;
 
   const result = utils.getNewCache();
 
@@ -29,7 +29,7 @@ test.serial('if getNewCache will return a new WeakSet-like object when support i
   t.deepEqual(result._values, [value]);
   t.true(result.has(value));
 
-  constants.HAS_WEAKMAP_SUPPORT = support;
+  constants.HAS_WEAKSET_SUPPORT = support;
 });
 
 test('if getRegExpFlags will return an empty string when no flags are on the regExp', (t) => {


### PR DESCRIPTION
Also, add arguments to the list of types tested (they will be copied into standard objects)