### PR TITLE
Support objects created with custom prototypes via Object.create

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ import {
   HAS_WEAKSET_SUPPORT
 } from './constants';
 
-const {create, keys: getKeys, getOwnPropertySymbols: getSymbols} = Object;
+const {create, keys: getKeys, getOwnPropertySymbols: getSymbols, getPrototypeOf} = Object;
 const {propertyIsEnumerable} = Object.prototype;
 
 /**
@@ -179,7 +179,11 @@ export const copySet = createCopyIterable((iterable, copy, realm) => (value) => 
  * @returns {Object} the copied object
  */
 export const copyObject = (object, copy, realm, isPlainObject) => {
-  const newObject = isPlainObject ? {} : object.constructor ? new object.constructor() : create(null);
+  const newObject = isPlainObject
+    ? create(getPrototypeOf(object))
+    : object.constructor
+      ? new object.constructor()
+      : create(getPrototypeOf(object));
   const keys = getKeys(object);
 
   if (keys.length) {

--- a/test/index.js
+++ b/test/index.js
@@ -65,8 +65,16 @@ function Foo(value) {
   return this;
 }
 
+const CUSTOM_PROTOTYPE = {
+  value: 'value',
+  method() {
+    return 'foo';
+  }
+}
+
 const SPECIAL_TYPES = {
   foo: new Foo('value'),
+  customProto: Object.create(CUSTOM_PROTOTYPE),
   react: React.createElement('main', {
     children: [
       React.createElement('h1', {children: 'Title'}),
@@ -148,6 +156,7 @@ test.serial('if copy will copy the special types correctly', (t) => {
   Object.keys(SPECIAL_TYPES).forEach((key) => {
     t.not(result[key], SPECIAL_TYPES[key]);
     t.deepEqual(result[key], SPECIAL_TYPES[key], key);
+    t.is(Object.getPrototypeOf(result[key]), Object.getPrototypeOf(SPECIAL_TYPES[key]), key + ' prototypes do not match');
   });
 });
 


### PR DESCRIPTION
One of my projects has a sort of idiosyncratic way of stamping out objects. We have a prototype object, and then we build instances like this:

```js
const instance = Object.create(MyPrototype);
```

Unfortunately I have found that `fast-copy` cannot properly copy this - the copied object does not have the same prototype. We were previously using [`angular.copy`](https://docs.angularjs.org/api/ng/function/angular.copy) which supported this case.

I've added a test that shows this case, and one stab at a solution to it. Thanks for making this library, we're really excited to be using it!