### PR TITLE
Typings fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,10 +27,10 @@ declare namespace FastCopy {
   };
 }
 
-declare function copy<T>(object: any, options?: FastCopy.Options): T;
+declare function copy<T>(object: T, options?: FastCopy.Options): T;
 
 declare namespace copy {
-  function strictCopy<T>(object: any, options?: FastCopy.Options): T;
+  function strictCopy<T>(object: T, options?: FastCopy.Options): T;
 }
 
 export default copy;


### PR DESCRIPTION
Because you had `object: T` before, but now it becomes `any` and now I have TS7017 error:
`TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.`