### PR TITLE
manually coalesce the options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # fast-copy CHANGELOG
 
+## 2.0.2
+
+- Manually coalesce options instead of use destructuring (performance)
+
 ## 2.0.1
 
 - Fix typings declarations - [#17](https://github.com/planttheidea/fast-copy/pull/17)


### PR DESCRIPTION
Instead of defaulting to an object that is destructured, manually coalesce the options to their defaults. This is a small performance boost with the transpilation.