### PR TITLE
change "npm i" to "yarn (or npm i)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ _Custom constructors, React components, etc_
 
 ## Development
 
-Standard practice, clone the repo and `npm i` to get the dependencies. The following npm scripts are available:
+Standard practice, clone the repo and `yarn` (or `npm i`) to get the dependencies. The following npm scripts are available:
 
 - benchmark => run benchmark tests against other equality libraries
 - build => build dist files with `rollup`


### PR DESCRIPTION
because this package has a yarn.lock file, and no package-lock.json, I modified the readme appropriately.

instead of:
`npm i`

write:
`yarn` (or `npm i`)