### PR TITLE
#27 Handle copying referenced objects

### DIFF
--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -96,7 +96,9 @@ const CIRCULAR: PlainObject = {
       reference: {},
     },
   },
-  other: {},
+  other: {
+    reference: {}
+  },
 };
 
 CIRCULAR.deeply.nested.reference = CIRCULAR;
@@ -247,6 +249,31 @@ describe('copy', () => {
     expect(result).not.toBe(cleanComplexTypes);
     expect(result).toEqual(cleanComplexTypes);
   });
+
+  it('will copy referenced objects', () => {
+    const reusedObject = {
+      name: 'I like trains!'
+    };
+
+    const data = {
+      a: reusedObject,
+      b: reusedObject,
+      array: [reusedObject, reusedObject]
+    }
+
+    const result = copy(data);
+
+    const cloneReusedObject = result.a;
+
+    expect(result.a).not.toBe(reusedObject);
+    expect(result.a).toEqual(reusedObject);
+    expect(result.b).not.toBe(reusedObject);
+    expect(result.b).toBe(cloneReusedObject);
+    expect(result.array[0]).not.toBe(reusedObject);
+    expect(result.array[0]).toBe(cloneReusedObject);
+    expect(result.array[1]).not.toBe(reusedObject);
+    expect(result.array[1]).toBe(cloneReusedObject);
+  })
 });
 
 describe('copy.strict', () => {
@@ -393,4 +420,29 @@ describe('copy.strict', () => {
     expect(result).toEqual(cleanComplexTypes);
     expect(result2).toEqual(cleanComplexTypes);
   });
+
+  it('will copy referenced objects', () => {
+    const reusedObject = {
+      name: 'I like trains!'
+    };
+
+    const data = {
+      a: reusedObject,
+      b: reusedObject,
+      array: [reusedObject, reusedObject]
+    }
+
+    const result = copy(data, { isStrict: true });
+
+    const cloneReusedObject = result.a;
+
+    expect(result.a).not.toBe(reusedObject);
+    expect(result.a).toEqual(reusedObject);
+    expect(result.b).not.toBe(reusedObject);
+    expect(result.b).toBe(cloneReusedObject);
+    expect(result.array[0]).not.toBe(reusedObject);
+    expect(result.array[0]).toBe(cloneReusedObject);
+    expect(result.array[1]).not.toBe(reusedObject);
+    expect(result.array[1]).toBe(cloneReusedObject);
+  })
 });

--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -13,39 +13,46 @@ type PlainObject = {
 };
 
 describe('createCache', () => {
-  it('will create a cache based on WeakSet if available globally', () => {
-    const support = SUPPORTS.WEAKSET;
+  it('will create a cache based on WeakMap if available globally', () => {
+    const support = SUPPORTS.WEAKMAP;
 
-    SUPPORTS.WEAKSET = true;
+    SUPPORTS.WEAKMAP = true;
 
     const result = createCache();
 
-    expect(result instanceof WeakSet).toBe(true);
+    expect(result instanceof WeakMap).toBe(true);
 
-    SUPPORTS.WEAKSET = support;
+    SUPPORTS.WEAKMAP = support;
   });
 
-  it('will create a cache based on a tiny WeakSet fill if not available globally', () => {
-    const support = SUPPORTS.WEAKSET;
+  it('will create a cache based on a tiny WeakMap fill if not available globally', () => {
+    const support = SUPPORTS.WEAKMAP;
 
-    SUPPORTS.WEAKSET = false;
+    SUPPORTS.WEAKMAP = false;
 
     const result = createCache();
 
-    expect(result instanceof WeakSet).toBe(false);
+    expect(result instanceof WeakMap).toBe(false);
 
     expect(result).toEqual({
+      _keys: [],
       _values: [],
     });
 
-    const value = {};
+    const key = { key: 'key' };
+    const value = { value: 'value' };
 
-    result.add(value);
+    result.set(key, value);
 
+    expect(result._keys).toEqual([key]);
     expect(result._values).toEqual([value]);
-    expect(result.has(value)).toBe(true);
+    expect(result.has(key)).toBe(true);
+    expect(result.get(key)).toBe(value);
+    const otherKey = {};
+    expect(result.has(otherKey)).toBeFalsy();
+    expect(result.get(otherKey)).toBeUndefined();
 
-    SUPPORTS.WEAKSET = support;
+    SUPPORTS.WEAKMAP = support;
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "author": "tony_quetano@planttheidea.com",
+  "contributors": ["Dariusz Rzepka <rzepkadarek@gmail.com>"],
   "browser": "dist/fast-copy.js",
   "bugs": {
     "url": "https://github.com/planttheidea/fast-copy/issues"

--- a/src/fast-copy.d.ts
+++ b/src/fast-copy.d.ts
@@ -3,9 +3,11 @@ declare namespace FastCopy {
   export type Realm = Window | Global;
 
   export interface Cache {
+    _keys?: any[];
     _values?: any[];
-    add: (value: any) => void;
     has: (value: any) => boolean;
+    set: (key: any, value: any) => void;
+    get: (key: any) => any;
   }
 
   export type Copier = (object: any, cache: Cache) => any;


### PR DESCRIPTION
Solves #27 

Regarding using WeakMap - can we require to use a polyfill for that or we want to implement some simple implementation of it? It's widely supported across different browsers - https://caniuse.com/#search=weakmap


Benchmark - it's slightly slower with this fix. Maybe we can improve something? Or is simply WeakMap that much slower than the WeakSet?
```
Starting benchmarks for group simple object...
Master:
Benchmark completed for fast-copy: 2,258,798 ops/sec
Benchmark completed for fast-copy (strict): 514,319 ops/sec
After:
Benchmark completed for fast-copy: 2,235,410 ops/sec
Benchmark completed for fast-copy (strict): 479,978 ops/sec
```
```
Starting benchmarks for group complex object...
Master:
Benchmark completed for fast-copy: 100,285 ops/sec
Benchmark completed for fast-copy (strict): 34,349 ops/sec
After:
Benchmark completed for fast-copy: 82,292 ops/sec
Benchmark completed for fast-copy (strict): 30,649 ops/sec
```
```
Starting benchmarks for group circular object...
Master:
Benchmark completed for fast-copy: 1,200,336 ops/sec
Benchmark completed for fast-copy (strict): 372,298 ops/sec
After:
Benchmark completed for fast-copy: 1,193,205 ops/sec
Benchmark completed for fast-copy (strict): 354,410 ops/sec
```

```
Benchmark results complete, overall averages:
Master:
┌────────────────────┬───────────┐
│ Name               │ Ops / sec │
├────────────────────┼───────────┤
│ fast-copy          │ 667.553   │
├────────────────────┼───────────┤
│ lodash.cloneDeep   │ 506.869   │
├────────────────────┼───────────┤
│ clone              │ 445.201   │
├────────────────────┼───────────┤
│ ramda              │ 344.407   │
├────────────────────┼───────────┤
│ fast-deepclone     │ 278.045   │
├────────────────────┼───────────┤
│ deepclone          │ 250.351   │
├────────────────────┼───────────┤
│ fast-copy (strict) │ 204.973   │
├────────────────────┼───────────┤
│ fast-clone         │ 162.576   │
└────────────────────┴───────────┘
After:
┌────────────────────┬───────────┐
│ Name               │ Ops / sec │
├────────────────────┼───────────┤
│ fast-copy          │ 718.736   │
├────────────────────┼───────────┤
│ lodash.cloneDeep   │ 520.245   │
├────────────────────┼───────────┤
│ clone              │ 435.118   │
├────────────────────┼───────────┤
│ ramda              │ 390.288   │
├────────────────────┼───────────┤
│ fast-deepclone     │ 325.057   │
├────────────────────┼───────────┤
│ deepclone          │ 262.127   │
├────────────────────┼───────────┤
│ fast-clone         │ 172.48    │
├────────────────────┼───────────┤
│ fast-copy (strict) │ 155.235   │
└────────────────────┴───────────┘
```


