### PR TITLE
add support for Blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following object types are deeply cloned when they are either properties on 
 
 - `Array`
 - `ArrayBuffer`
+- `Blob`
 - `Buffer`
 - `DataView`
 - `Date`

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -69,6 +69,7 @@ const COMPLEX_TYPES: PlainObject = {
   object: { foo: { bar: 'baz' } },
   regexp: /foo/,
   set: new Set().add('foo').add({ bar: { baz: 'quz' } }),
+  blob: new Blob(['<a id="a">hey!</a>'], {type : 'text/html'}),
   uint8Array: new Uint8Array([12, 15]),
   uint8ClampedArray: new Uint8ClampedArray([12, 15]),
   uint16Array: new Uint16Array([12, 15]),
@@ -240,6 +241,7 @@ describe('copy', () => {
       Map: global.Map,
       RegExp: global.RegExp,
       Set: global.Set,
+      Blob: global.Blob,
       WeakMap: global.WeakMap,
       WeakSet: global.WeakSet,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,12 @@ function copy<T>(object: T, options?: FastCopy.Options): T {
       return clone;
     }
 
+    // blobs
+    if (realm.Blob && object instanceof realm.Blob) {
+      clone = new Blob([object], { type: object.type });
+      return clone
+    }
+
     // buffers (node-only)
     if (realm.Buffer && realm.Buffer.isBuffer(object)) {
       clone = realm.Buffer.allocUnsafe


### PR DESCRIPTION
without this fix a `Blob` goes into the `// assume anything left is a custom constructor` block. There the copied `Blob` gets empty.