### PR TITLE
test: add failing test for object with constructor

### DIFF
--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -115,6 +115,12 @@ class Foo {
   }
 }
 
+class Bar {
+  constructor(value: any) {
+    this.constructor = value;
+  }
+}
+
 const SPECIAL_TYPES: PlainObject = {
   foo: new Foo('value'),
   react: React.createElement('main', {
@@ -279,14 +285,24 @@ describe('copy', () => {
     expect(result.array[1]).toBe(cloneReusedObject);
   });
   
-  it('will copy an object with a constructor property', () => {
+  it('will copy a plain object with a constructor property', () => {
     const data = {
-      'constructor': 'I am unable to comply.'
-    }
+      constructor: 'I am unable to comply.',
+    };
     const result = copy(data);
 
     expect(result).not.toBe(data);
     expect(result).toEqual(data);
+    expect(Object.getPrototypeOf(result)).toBe(Object.getPrototypeOf(data));
+  });
+
+  it('will copy a object with a constructor property', () => {
+    const bar = new Bar('value');
+    const result = copy(bar);
+
+    expect(result).not.toBe(bar);
+    expect(result).toEqual(bar);
+    expect(Object.getPrototypeOf(result)).toBe(Object.getPrototypeOf(bar));
   });
 });
 

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -281,7 +281,7 @@ describe('copy', () => {
   
   it('will copy an object with a constructor property', () => {
     const data = {
-      'sys[constructor]': 'I am unable to comply.'
+      'constructor': 'I am unable to comply.'
     }
     const result = copy(data);
 

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -277,7 +277,17 @@ describe('copy', () => {
     expect(result.array[0]).toBe(cloneReusedObject);
     expect(result.array[1]).not.toBe(reusedObject);
     expect(result.array[1]).toBe(cloneReusedObject);
-  })
+  });
+  
+  it('will copy an object with a constructor property', () => {
+    const data = {
+      'sys[constructor]': 'I am unable to comply.'
+    }
+    const result = copy(data);
+
+    expect(result).not.toBe(data);
+    expect(result).toEqual(data);
+  });
 });
 
 describe('copy.strict', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,7 +62,7 @@ export const createCache = (): FastCopy.Cache => {
  * @returns the empty cloned object
  */
 export const getCleanClone = (object: any, realm: FastCopy.Realm): any => {
-  if (!object.constructor || !(object.constructor instanceof Function)) {
+  if (!object.constructor) {
     return create(null);
   }
 
@@ -73,7 +73,10 @@ export const getCleanClone = (object: any, realm: FastCopy.Realm): any => {
     return prototype === realm.Object.prototype ? {} : create(prototype);
   }
 
-  if (~toStringFunction.call(Constructor).indexOf('[native code]')) {
+  if (
+    typeof Constructor === 'function' &&
+    ~toStringFunction.call(Constructor).indexOf('[native code]')
+  ) {
     try {
       return new Constructor();
     } catch {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,7 +62,7 @@ export const createCache = (): FastCopy.Cache => {
  * @returns the empty cloned object
  */
 export const getCleanClone = (object: any, realm: FastCopy.Realm): any => {
-  if (!object.constructor) {
+  if (!object.constructor || !(object.constructor instanceof Function)) {
     return create(null);
   }
 


### PR DESCRIPTION
The following currently causes a fatal error with this module (while working with lodash):
```
copy({ 'sys[constructor]': 'something' })
```

The error looks like this:
```
TypeError: Function.prototype.toString required that 'this' be a Function
    at  String.toString.(<anonymous>)
    at  getCleanClone (/app/node_modules/fast-copy/src/utils.ts:76:25
    at  getObjectCloneLoose (/app/node_modules/fast-copy/src/utils.ts:103:22
    at  handleCopy (/app/node_modules/fast-copy/src/index.ts:182:12
    at  getObjectCloneLoose (/app/node_modules/fast-copy/src/utils.ts:109:20
    at  handleCopy (/app/node_modules/fast-copy/src/index.ts:72:14
    at  copy (/app/node_modules/fast-copy/src/index.ts:185:10
```

Version used: `"fast-copy": "^2.1.1"`

I added a test case to confirm that this is an error. Once I got a failing test as confirmation, I would implement the first solution from [this SO post](https://stackoverflow.com/a/19717946/17269164) which seems to be quite performant.

Greetings,
Thomas

cc @johanneswuerbach