### PR TITLE
fix: adding exports entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,12 @@
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.8.1"
   },
+  "exports": {
+    ".": {
+      "require": "./dist/fast-copy.cjs.js",
+      "import": "./dist/fast-copy.esm.js"
+    }
+  },
   "homepage": "https://github.com/planttheidea/fast-copy#readme",
   "keywords": [
     "clone",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "exports": {
     ".": {
       "require": "./dist/fast-copy.cjs.js",
-      "import": "./dist/fast-copy.esm.js"
+      "import": "./dist/fast-copy.esm.js",
+      "default": "./dist/fast-copy.js"
     }
   },
   "homepage": "https://github.com/planttheidea/fast-copy#readme",


### PR DESCRIPTION
Hi,
as fast-copy ships bundles for both `commonjs` and `esmodule`, it should be better to explicitly define which file to use for each module type, in order to avoid any kind of trouble at runtime.