### PR TITLE
fix: make it compatible with node's --disable-proto=throw

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,7 @@ export function createCopier(options: CreateCopierOptions) {
       return state.cache.get(value);
     }
 
-    state.prototype = value.__proto__ || getPrototypeOf(value);
+    state.prototype = !!getPrototypeOf ? getPrototypeOf(value) : value.__proto__;
     state.Constructor = state.prototype && state.prototype.constructor;
 
     // plain objects

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export type { State } from './copier';
 
 const { isArray } = Array;
 const { assign } = Object;
-const getPrototypeOf = Object.getPrototypeOf || (obj) => obj.__proto__
+const getPrototypeOf = Object.getPrototypeOf || ((obj) => obj.__proto__)
 
 export interface CreateCopierOptions {
   array?: InternalCopier<any[]>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export type { State } from './copier';
 const { isArray } = Array;
 const { assign, getPrototypeOf } = Object;
 
+const _getPrototypeOf = getPrototypeOf || (obj) => obj.__proto__
+
 export interface CreateCopierOptions {
   array?: InternalCopier<any[]>;
   arrayBuffer?: InternalCopier<ArrayBuffer>;
@@ -116,7 +118,7 @@ export function createCopier(options: CreateCopierOptions) {
       return state.cache.get(value);
     }
 
-    state.prototype = !!getPrototypeOf ? getPrototypeOf(value) : value.__proto__;
+    state.prototype = _getPrototypeOf(value);
     state.Constructor = state.prototype && state.prototype.constructor;
 
     // plain objects

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,8 @@ import type { InternalCopier, State } from './copier';
 export type { State } from './copier';
 
 const { isArray } = Array;
-const { assign, getPrototypeOf } = Object;
-
-const _getPrototypeOf = getPrototypeOf || (obj) => obj.__proto__
+const { assign } = Object;
+const getPrototypeOf = Object.getPrototypeOf || (obj) => obj.__proto__
 
 export interface CreateCopierOptions {
   array?: InternalCopier<any[]>;
@@ -118,7 +117,7 @@ export function createCopier(options: CreateCopierOptions) {
       return state.cache.get(value);
     }
 
-    state.prototype = _getPrototypeOf(value);
+    state.prototype = getPrototypeOf(value);
     state.Constructor = state.prototype && state.prototype.constructor;
 
     // plain objects


### PR DESCRIPTION
Many people use the option [`--disable-proto=delete`/`--disable-proto=throw`](https://nodejs.org/api/cli.html#--disable-protomode) in NodeJS to minimise the probability of prototype pollution attacks. Because of that, `__proto__` might not be available (or throw an error if accessed).

- Fixes #79 