### PR TITLE
[#94] Support for cloning an `Empty` class instance from `fast-querystring`

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -56,7 +56,7 @@ describe('createCache', () => {
 });
 
 describe('getCleanClone', () => {
-  it('will return a pure object when there is no constructor', () => {
+  it('will return a pure object when there is no prototype', () => {
     const object = Object.create(null);
 
     const result = utils.getCleanClone(Object.getPrototypeOf(object));
@@ -65,6 +65,23 @@ describe('getCleanClone', () => {
     expect(result).toEqual(object);
 
     expect(Object.getPrototypeOf(result)).toBe(null);
+  });
+
+  it('will return a pure object when there is a prototype but no constructor', () => {
+    const Empty = function () {
+      // empty
+    };
+    Empty.prototype = Object.create(null);
+
+    // @ts-expect-error - Testing `fast-querystring` V8 optimization
+    const object = new Empty();
+
+    const result = utils.getCleanClone(Object.getPrototypeOf(object));
+
+    expect(result).not.toBe(object);
+    expect(result).toEqual(object);
+
+    expect(Object.getPrototypeOf(result)).toBe(Empty.prototype);
   });
 
   it('will return a pure object when there is no __proto__ property', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,7 +57,10 @@ export function getCleanClone(prototype: any): any {
     return prototype === Object.prototype ? {} : create(prototype);
   }
 
-  if (~toStringFunction.call(Constructor).indexOf('[native code]')) {
+  if (
+    Constructor &&
+    ~toStringFunction.call(Constructor).indexOf('[native code]')
+  ) {
     try {
       return new Constructor();
     } catch {}


### PR DESCRIPTION
## Reason for change
In #94 , it was identified that cloning an object with a prototype that lacks a constructor will fail.

```ts
const Empty = function() {};
Empty.prototype = Object.create(null);

const object = new Empty();
const clone = copy(object);
```

It was failing on calling `Function.prototype.toString` on the `prototype.constructor`, which was null.

## Change
Check for the existence of the constructor before calling `toString` on it. In the above case, it causes the condition to fail, falling back to using `Object.create` to construct a new object with the `Empty.prototype`.