### PR TITLE
add JSON.parse/JSON.stringify to the benchmark

### DIFF
--- a/benchmark/index.cjs
+++ b/benchmark/index.cjs
@@ -106,6 +106,7 @@ const packages = {
   // 'fast-deepclone': require('fast-deepclone'),
   'lodash.cloneDeep': require('lodash').cloneDeep,
   ramda: require('ramda').clone,
+  "node-json": (o) => JSON.parse(JSON.stringify(o)),
 };
 
 const suite = createSuite({


### PR DESCRIPTION
Hi,

I would like to add the JSON.parse(JSON.stringify(object)) method to the benchmark.

It makes sense to use it for POCO objects and a native approach.

In my Mac M4, the results were interesting (even 2nd place, after this library).

NOTE: I'm adding this to the benchmark, but not to the README, because my results will not be consistent.

Thanks