### PR TITLE
[Cleanup] Remove `allowImportFromTsExtensions` in `tsconfig.json`

### DIFF
--- a/scripts/create-cts-files.js
+++ b/scripts/create-cts-files.js
@@ -7,7 +7,10 @@ async function createCtsFiles() {
 
   for (const file of definitionFiles) {
     const content = readFileSync(`./dist/cjs/types/${file}`, 'utf-8');
-    const updatedContent = content.replaceAll('.ts', '.d.cts');
+    const updatedContent = content
+      .replaceAll('.ts', '.d.cts')
+      .replaceAll('.js', '.d.cts')
+      .replaceAll('import {', 'import type {');
 
     writeFileSync(`./dist/cjs/types/${file}`, updatedContent, 'utf-8');
 

--- a/scripts/create-mts-files.js
+++ b/scripts/create-mts-files.js
@@ -7,7 +7,10 @@ async function createMtsFiles() {
 
   for (const file of definitionFiles) {
     const content = readFileSync(`./dist/esm/types/${file}`, 'utf-8');
-    const updatedContent = content.replaceAll('.ts', '.d.mts');
+    const updatedContent = content
+      .replaceAll('.ts', '.d.mts')
+      .replaceAll('.js', '.d.mts')
+      .replaceAll('import {', 'import type {');
 
     writeFileSync(`./dist/esm/types/${file}`, updatedContent, 'utf-8');
 

--- a/src/__tests__/copier.ts
+++ b/src/__tests__/copier.ts
@@ -12,8 +12,8 @@ import {
   copyObjectStrict,
   copyPrimitiveWrapper,
   copySetStrict,
-} from '../copier.ts';
-import { createDefaultCache } from '../options.ts';
+} from '../copier.js';
+import { createDefaultCache } from '../options.js';
 
 describe('copyArrayStrict', () => {
   it('will copy both indices and explicit properties', () => {

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import React from 'react';
 
-import { copy, copyStrict } from '../index.ts';
+import { copy, copyStrict } from '../index.js';
 
 interface PlainObject {
   [key: string]: any;

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getCleanClone } from '../utils.ts';
+import { getCleanClone } from '../utils.js';
 
 interface PlainObject {
   [key: string]: any;

--- a/src/copier.ts
+++ b/src/copier.ts
@@ -1,4 +1,4 @@
-import { getCleanClone } from './utils.ts';
+import { getCleanClone } from './utils.js';
 
 import type { Cache } from './utils.ts';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { getOptions } from './options.ts';
-import { getTag } from './utils.ts';
+import { getOptions } from './options.js';
+import { getTag } from './utils.js';
 
 import type { State } from './copier.ts';
 import type { CreateCopierOptions } from './options.ts';

--- a/src/options.ts
+++ b/src/options.ts
@@ -15,7 +15,7 @@ import {
   copySelf,
   copySetLoose,
   copySetStrict,
-} from './copier.ts';
+} from './copier.js';
 import type { Cache } from './utils.ts';
 
 export interface CopierMethods {

--- a/tsconfig/base.json
+++ b/tsconfig/base.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowImportingTsExtensions": true,
     "baseUrl": "src",
     "esModuleInterop": true,
     "jsx": "react",


### PR DESCRIPTION
## Reason for change

`rollup` is barking because the option is enabled, and I'm not sure if this can cause hidden issues for later. It is no longer necessary now that we have switched from `jest` to `vitest`, so we can remove it in favor of standard `.js` extensions.

## Change

Remove the compiler option, and update the imports. I updated the types scripts to ensure that `.js` imports were transformed as well.